### PR TITLE
Disambiguate bot and user tokens since bot token is only needed for rtm.start

### DIFF
--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackCustomConnection.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackCustomConnection.java
@@ -23,7 +23,7 @@ public class SlackCustomConnection
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token")
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-user-auth-token", "my-bot-auth-token")
                                                   .withProxy(Proxy.Type.HTTP, "my.proxy.address", 1234)
                                               .withAutoreconnectOnDisconnection(false)
                 .withConnectionHeartbeat(10, TimeUnit.SECONDS)

--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnection.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnection.java
@@ -13,7 +13,7 @@ public class SlackDirectConnection
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.createWebSocketSlackSession("my-bot-auth-token");
+        SlackSession session = SlackSessionFactory.createWebSocketSlackSession("my-user-auth-token", "my-bot-auth-token");
         session.connect();
     }
 }

--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnectionWithBuilder.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnectionWithBuilder.java
@@ -13,7 +13,7 @@ public class SlackDirectConnectionWithBuilder
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token").build();
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-user-auth-token", "my-bot-auth-token").build();
         session.connect();
     }
 }

--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackProxyConnection.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackProxyConnection.java
@@ -14,7 +14,7 @@ public class SlackProxyConnection
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token")
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-user-auth-token", "my-bot-auth-token")
                                                   .withProxy(Proxy.Type.HTTP, "my.proxy.address", 1234)
                                                   .build();
         session.connect();

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ChannelHistoryModuleImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ChannelHistoryModuleImpl.java
@@ -29,9 +29,9 @@ import com.ullink.slack.simpleslackapi.listeners.SlackMessagePostedListener;
 public class ChannelHistoryModuleImpl implements ChannelHistoryModule {
 
     private final SlackSession session;
-    private static final String FETCH_CHANNEL_HISTORY_COMMAND = "channels.history";
-    private static final String FETCH_GROUP_HISTORY_COMMAND = "groups.history";
-    private static final String FETCH_IM_HISTORY_COMMAND = "im.history";
+    private static final String FETCH_CHANNEL_HISTORY_COMMAND = "conversations.history";
+    private static final String FETCH_GROUP_HISTORY_COMMAND = "conversations.history";
+    private static final String FETCH_IM_HISTORY_COMMAND = "conversations.history";
     private static final int DEFAULT_HISTORY_FETCH_SIZE = 1000;
 
     public ChannelHistoryModuleImpl(SlackSession session) {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
@@ -7,18 +7,19 @@ import com.ullink.slack.simpleslackapi.SlackSession;
 import com.ullink.slack.simpleslackapi.WebSocketContainerProvider;
 
 public class SlackSessionFactory {
-    public static SlackSession createWebSocketSlackSession(String authToken)
+    public static SlackSession createWebSocketSlackSession(String authToken, String botToken)
     {
-    	return new SlackWebSocketSessionImpl(null, authToken, null, true, true, 0, null);
+    	return new SlackWebSocketSessionImpl(null, authToken, botToken, null, true, true, 0, null);
     }
 
-    public static SlackSessionFactoryBuilder getSlackSessionBuilder(String authToken) {
-        return new SlackSessionFactoryBuilder(authToken);
+    public static SlackSessionFactoryBuilder getSlackSessionBuilder(String authToken, String botToken) {
+        return new SlackSessionFactoryBuilder(authToken, botToken);
     }
 
     public static class SlackSessionFactoryBuilder {
 
         private String authToken;
+        private String botToken;
         private String slackBaseApi;
         private Proxy.Type proxyType;
         private String proxyAddress;
@@ -31,8 +32,9 @@ public class SlackSessionFactory {
         private boolean autoreconnection;
         private boolean rateLimitSupport = true;
 
-        private SlackSessionFactoryBuilder(String authToken) {
+        private SlackSessionFactoryBuilder(String authToken, String botToken) {
             this.authToken = authToken;
+            this.botToken = botToken;
         }
 
         public SlackSessionFactoryBuilder withBaseApiUrl(String slackBaseApi) {
@@ -78,7 +80,7 @@ public class SlackSessionFactory {
         }
 
         public SlackSession build() {
-            return new SlackWebSocketSessionImpl(provider, authToken, slackBaseApi, proxyType, proxyAddress, proxyPort, proxyUser, proxyPassword, autoreconnection, rateLimitSupport, heartbeat, unit);
+            return new SlackWebSocketSessionImpl(provider, authToken, botToken, slackBaseApi, proxyType, proxyAddress, proxyPort, proxyUser, proxyPassword, autoreconnection, rateLimitSupport, heartbeat, unit);
         }
     }
 }

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackWebSocketSessionImpl.java
@@ -155,6 +155,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
 
     private volatile Session websocketSession;
     private final    String  authToken;
+    private final    String  botToken;
     private          String  slackApiBase               = DEFAULT_SLACK_API_HTTPS_ROOT;
     private String                            proxyAddress;
     private int                               proxyPort                  = -1;
@@ -308,12 +309,13 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         }
     }
 
-    SlackWebSocketSessionImpl(WebSocketContainerProvider webSocketContainerProvider, String authToken, String slackApiBase, boolean reconnectOnDisconnection, boolean isRateLimitSupported, long heartbeat, TimeUnit unit) {
-    	this(webSocketContainerProvider, authToken, slackApiBase, null, null, -1, null, null, reconnectOnDisconnection, isRateLimitSupported, heartbeat, unit);
+    SlackWebSocketSessionImpl(WebSocketContainerProvider webSocketContainerProvider, String authToken, String botToken, String slackApiBase, boolean reconnectOnDisconnection, boolean isRateLimitSupported, long heartbeat, TimeUnit unit) {
+    	this(webSocketContainerProvider, authToken, botToken, slackApiBase, null, null, -1, null, null, reconnectOnDisconnection, isRateLimitSupported, heartbeat, unit);
     }
 
-    SlackWebSocketSessionImpl(WebSocketContainerProvider webSocketContainerProvider, String authToken, String slackApiBase, Proxy.Type proxyType, String proxyAddress, int proxyPort, String proxyUser, String proxyPassword, boolean reconnectOnDisconnection, boolean isRateLimitSupported, long heartbeat, TimeUnit unit) {
+    SlackWebSocketSessionImpl(WebSocketContainerProvider webSocketContainerProvider, String authToken, String botToken, String slackApiBase, Proxy.Type proxyType, String proxyAddress, int proxyPort, String proxyUser, String proxyPassword, boolean reconnectOnDisconnection, boolean isRateLimitSupported, long heartbeat, TimeUnit unit) {
         this.authToken = authToken;
+        this.botToken = botToken;
         if (slackApiBase != null) {
         	this.slackApiBase = slackApiBase;
         }
@@ -384,7 +386,7 @@ class SlackWebSocketSessionImpl extends AbstractSlackSessionImpl implements Slac
         HttpClient httpClient = getHttpClient();
         HttpPost request = new HttpPost(slackApiBase + "rtm.start");
         request.setHeader(HttpHeaders.CONTENT_TYPE,"application/x-www-form-urlencoded");
-        request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authToken);
+        request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + botToken);
         HttpResponse response = httpClient.execute(request);
         LOGGER.debug(response.getStatusLine().toString());
         String jsonResponse = consumeToString(response.getEntity().getContent());


### PR DESCRIPTION
Fixes (or at least works around) https://github.com/Itiviti/simple-slack-api/issues/279

More context: https://api.slack.com/bot-users#bot_methods__methods-for-the-modern-bot

Slack has added new scopes that are not available to "classic" bots. However, simple-slack-api bots are required to be classic since it uses the rtm api (https://api.slack.com/rtm). My fix/workaround is to use the app's user token instead of bot token to use these scopes.

An alternative (better?) fix would be to replace rtm.start with modern calls to pull the necessary info when creating a session.