### PR TITLE
Fix #279 by moving to granular bot auth scopes

### DIFF
--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackCustomConnection.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackCustomConnection.java
@@ -23,7 +23,7 @@ public class SlackCustomConnection
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token")
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token", "my-bot-app-level-token")
                                                   .withProxy(Proxy.Type.HTTP, "my.proxy.address", 1234)
                                               .withAutoreconnectOnDisconnection(false)
                 .withConnectionHeartbeat(10, TimeUnit.SECONDS)

--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnection.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnection.java
@@ -13,7 +13,7 @@ public class SlackDirectConnection
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.createWebSocketSlackSession("my-bot-auth-token");
+        SlackSession session = SlackSessionFactory.createWebSocketSlackSession("my-bot-auth-token", "my-bot-app-level-token");
         session.connect();
     }
 }

--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnectionWithBuilder.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackDirectConnectionWithBuilder.java
@@ -13,7 +13,7 @@ public class SlackDirectConnectionWithBuilder
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token").build();
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token", "my-bot-app-level-token").build();
         session.connect();
     }
 }

--- a/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackProxyConnection.java
+++ b/samples/connection/src/main/java/com/ullink/slack/simpleslackapi/samples/connection/SlackProxyConnection.java
@@ -14,7 +14,7 @@ public class SlackProxyConnection
 {
     public static void main(String[] args) throws IOException
     {
-        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token")
+        SlackSession session = SlackSessionFactory.getSlackSessionBuilder("my-bot-auth-token", "my-bot-app-level-token")
                                                   .withProxy(Proxy.Type.HTTP, "my.proxy.address", 1234)
                                                   .build();
         session.connect();

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ChannelHistoryModuleImpl.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/ChannelHistoryModuleImpl.java
@@ -29,9 +29,9 @@ import com.ullink.slack.simpleslackapi.listeners.SlackMessagePostedListener;
 public class ChannelHistoryModuleImpl implements ChannelHistoryModule {
 
     private final SlackSession session;
-    private static final String FETCH_CHANNEL_HISTORY_COMMAND = "channels.history";
-    private static final String FETCH_GROUP_HISTORY_COMMAND = "groups.history";
-    private static final String FETCH_IM_HISTORY_COMMAND = "im.history";
+    private static final String FETCH_CHANNEL_HISTORY_COMMAND = "conversations.history";
+    private static final String FETCH_GROUP_HISTORY_COMMAND = "conversations.history";
+    private static final String FETCH_IM_HISTORY_COMMAND = "conversations.history";
     private static final int DEFAULT_HISTORY_FETCH_SIZE = 1000;
 
     public ChannelHistoryModuleImpl(SlackSession session) {

--- a/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
+++ b/sources/src/main/java/com/ullink/slack/simpleslackapi/impl/SlackSessionFactory.java
@@ -7,18 +7,19 @@ import com.ullink.slack.simpleslackapi.SlackSession;
 import com.ullink.slack.simpleslackapi.WebSocketContainerProvider;
 
 public class SlackSessionFactory {
-    public static SlackSession createWebSocketSlackSession(String authToken)
+    public static SlackSession createWebSocketSlackSession(String authToken, String appLevelToken)
     {
-    	return new SlackWebSocketSessionImpl(null, authToken, null, true, true, 0, null);
+    	return new SlackWebSocketSessionImpl(null, authToken, appLevelToken, null, true, true, 0, null);
     }
 
-    public static SlackSessionFactoryBuilder getSlackSessionBuilder(String authToken) {
-        return new SlackSessionFactoryBuilder(authToken);
+    public static SlackSessionFactoryBuilder getSlackSessionBuilder(String authToken, String appLevelToken) {
+        return new SlackSessionFactoryBuilder(authToken, appLevelToken);
     }
 
     public static class SlackSessionFactoryBuilder {
 
         private String authToken;
+        private String appLevelToken;
         private String slackBaseApi;
         private Proxy.Type proxyType;
         private String proxyAddress;
@@ -31,8 +32,9 @@ public class SlackSessionFactory {
         private boolean autoreconnection;
         private boolean rateLimitSupport = true;
 
-        private SlackSessionFactoryBuilder(String authToken) {
+        private SlackSessionFactoryBuilder(String authToken, String appLevelToken) {
             this.authToken = authToken;
+            this.appLevelToken = appLevelToken;
         }
 
         public SlackSessionFactoryBuilder withBaseApiUrl(String slackBaseApi) {
@@ -78,7 +80,7 @@ public class SlackSessionFactory {
         }
 
         public SlackSession build() {
-            return new SlackWebSocketSessionImpl(provider, authToken, slackBaseApi, proxyType, proxyAddress, proxyPort, proxyUser, proxyPassword, autoreconnection, rateLimitSupport, heartbeat, unit);
+            return new SlackWebSocketSessionImpl(provider, authToken, appLevelToken, slackBaseApi, proxyType, proxyAddress, proxyPort, proxyUser, proxyPassword, autoreconnection, rateLimitSupport, heartbeat, unit);
         }
     }
 }


### PR DESCRIPTION
Moving away from the umbrella bot auth scope, to the modern granular scopes. For more info see:
https://api.slack.com/authentication/migration
https://api.slack.com/authentication/quickstart

This change aims to leave as much of simple-slack-api as possible intact, by replacing the fields that `rtm.start` used to expose with matching ones from a variety of modern endpoints.